### PR TITLE
add .Rprofile

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,0 +1,1 @@
+source("renv/activate.R")

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .Rhistory
 .RData
 .Ruserdata
-.Rprofile
 
 /.quarto/
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,30 @@ Welcome to the course booklet repository! :wave:
 To make this booklet FAIR (finable, accessible, interoperable, and reusable),
 we have created an OSF entry: https://osf.io/rupt7/
 
+## Requirements
+
+This repo uses [`renv`](https://rstudio.github.io/renv/articles/renv.html) for dependency management.
+
+If you haven't used `renv` before, install it using:
+
+```R
+install.packages("renv")
+```
+
+If you open the R project `berd-reproducible-research-course.Rproj` for the first time in RStudio, `renv` should be automatically activated.
+You are asked to install the packages listed in [`renv.lock`](renv.lock):
+
+```R
+# Bootstrapping renv 1.0.0 ---------------------------------------------------
+- Downloading renv ... OK
+- Installing renv  ... OK
+
+- Project '~/edu/berd-reproducible-research-course' loaded. [renv 1.0.0]
+- None of the packages recorded in the lockfile are installed.
+- Using `renv::restore()` to restore the project library.
+Do you want to proceed? [Y/n]: Y
+```
+
 ## Viewing the booklet
 To view the booklet, please run
 


### PR DESCRIPTION
this add the `.Rprofile` file which allows auto-activating renv in RStudio.

this results in renv giving this useful output, prompting the user to install packages using `renv::restore()`:

```r
# Bootstrapping renv 1.0.0 ---------------------------------------------------
- Downloading renv ... OK
- Installing renv  ... OK

- Project '~/edu/berd-reproducible-research-course' loaded. [renv 1.0.0]
- None of the packages recorded in the lockfile are installed.
- Using `renv::restore()` to restore the project library.
Do you want to proceed? [Y/n]: Y

The following package(s) will be updated:

# CRAN -----------------------------------------------------------------------
- base64enc     [* -> 0.1-3]
- bslib         [* -> 0.4.2]
- cachem        [* -> 1.0.7]
- cli           [* -> 3.6.1]
- digest        [* -> 0.6.31]
- ellipsis      [* -> 0.3.2]
- evaluate      [* -> 0.20]
- fastmap       [* -> 1.1.1]
- fontawesome   [* -> 0.5.1]
- fs            [* -> 1.6.2]
- glue          [* -> 1.6.2]
- highr         [* -> 0.10]
- htmltools     [* -> 0.5.5]
- jquerylib     [* -> 0.1.4]
- jsonlite      [* -> 1.8.4]
- knitr         [* -> 1.42]
- lifecycle     [* -> 1.0.3]
- magrittr      [* -> 2.0.3]
- memoise       [* -> 2.0.1]
- mime          [* -> 0.12]
- R6            [* -> 2.5.1]
- rappdirs      [* -> 0.3.3]
- rlang         [* -> 1.1.1]
- rmarkdown     [* -> 2.21]
- sass          [* -> 0.4.5]
- stringi       [* -> 1.7.12]
- stringr       [* -> 1.5.0]
- tinytex       [* -> 0.45]
- vctrs         [* -> 0.6.2]
- xfun          [* -> 0.39]
- yaml          [* -> 2.3.7]
```

fixes #3 