### PR TITLE
correct typo in make example r script

### DIFF
--- a/make-example/overview.R
+++ b/make-example/overview.R
@@ -6,7 +6,7 @@ by(data = pg$weight, INDICES = pg$group, FUN = summary)
 
 ## Show visual summary of plant weight by group and save as pdf
 png("boxplot_weight-group.png", width = 800, height = 600, res = 120)
-(p <- boxplot(weight ~ group, data = PlantGrowth, title = "Weight by treatment condition"))
+(p <- boxplot(weight ~ group, data = pg, main = "Weight by treatment condition"))
 dev.off()
 
 


### PR DESCRIPTION
There is a small mistake in the make-script R example: instead of using the new cleaned data `pg`, the script uses the corresponding default dataset `PlantGrowth`, which makes it not possible to see any differences when modifying the preprocessing. In addition, to add the title of the plot, the argument in base R is `main` and not `title` like in ggplot. :)  